### PR TITLE
Bump netlify_lambda to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,8 +356,9 @@ dependencies = [
 
 [[package]]
 name = "netlify_lambda"
-version = "0.1.3"
-source = "git+https://github.com/simnalamburt/aws-lambda-rust-runtime?branch=tokio-1.0#2366111f1818ac66567010bdd54f2ad89fce4f8c"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36ac09d2d6088a343a8c7451a28cd771d3f3a036423933e190509bd932a6fa"
 dependencies = [
  "async-stream",
  "bytes",
@@ -376,8 +377,9 @@ dependencies = [
 
 [[package]]
 name = "netlify_lambda_attributes"
-version = "0.1.1"
-source = "git+https://github.com/simnalamburt/aws-lambda-rust-runtime?branch=tokio-1.0#2366111f1818ac66567010bdd54f2ad89fce4f8c"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442468bf98c34f0673d646fa73083d80782c8e331844b98d2324974dc454f5e3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/sns-discord/Cargo.toml
+++ b/sns-discord/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-netlify_lambda = { git = "https://github.com/simnalamburt/aws-lambda-rust-runtime", branch = "tokio-1.0" }
+netlify_lambda = "0.2.0"
 tokio = "1.0.1"
 hyper = { version = "0.14.1", features = ["client", "http2", "http1"] }
 hyper-rustls = "0.22.0"


### PR DESCRIPTION
https://github.com/lamedh-dev/aws-lambda-rust-runtime/pull/8 has heen merged into the upstream and shiped with v0.2.0, let's use it!