### PR TITLE
Set a User-Agent header on the Discord webhook request

### DIFF
--- a/sns-discord/lambda_function.py
+++ b/sns-discord/lambda_function.py
@@ -26,7 +26,10 @@ def lambda_handler(event: Any, context: Any) -> None:
     request = urllib.request.Request(
         WEBHOOK_URL.format(webhook_token),
         data=json.dumps(payload).encode(),
-        headers={"Content-Type": "application/json"},
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "femiwiki-lambda-sns-discord (+https://github.com/femiwiki/lambda)",
+        },
         method="POST",
     )
     try:


### PR DESCRIPTION
Post-deploy check on #188 found that the live DiscordNoti function (Python 3.13, both regions) was silently failing to deliver alarms: `aws lambda invoke` with a synthetic `_Test` SNS event returned `200` from Lambda but the logged Discord response was `403` / `error code: 1010` (Cloudflare bot-signature block on the default `Python-urllib/3.x` User-Agent).

Fix: set an explicit `User-Agent` header on the webhook request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)