### PR TITLE
Fix chart image fetch and minimize the embed when a chart is attached

### DIFF
--- a/sns-discord/lambda_function.py
+++ b/sns-discord/lambda_function.py
@@ -34,19 +34,14 @@ def lambda_handler(event: Any, context: Any) -> None:
     webhook_token = os.environ["WEBHOOK_TOKEN"]
     post_data = parse_message(event)
 
-    payload = {
-        "content": post_data["content"],
-        "embeds": [post_data["embed"]],
-        "allowed_mentions": {"roles": [MENTION_ROLE]},
-    }
-
     trigger = post_data["trigger"]
     chart = fetch_chart_image(trigger) if trigger else None
+    payload = build_payload(post_data, chart)
+
     if chart is None:
         body = json.dumps(payload).encode()
         content_type = "application/json"
     else:
-        payload["embeds"][0]["image"] = {"url": "attachment://chart.png"}
         body = encode_multipart(payload, chart)
         content_type = f"multipart/form-data; boundary={MULTIPART_BOUNDARY}"
 
@@ -77,6 +72,22 @@ def lambda_handler(event: Any, context: Any) -> None:
             ensure_ascii=False,
         )
     )
+
+
+def build_payload(post_data: dict[str, Any], chart: bytes | None) -> dict[str, Any]:
+    embed = post_data["embed"]
+    if chart is not None:
+        embed = {
+            **embed,
+            "description": "",
+            "fields": [],
+            "image": {"url": "attachment://chart.png"},
+        }
+    return {
+        "content": post_data["content"],
+        "embeds": [embed],
+        "allowed_mentions": {"roles": [MENTION_ROLE]},
+    }
 
 
 def parse_message(event: Any) -> dict[str, Any]:
@@ -220,7 +231,7 @@ def fetch_chart_image(trigger: dict[str, Any]) -> bytes | None:
         response = cloudwatch.get_metric_widget_image(
             MetricWidget=json.dumps(widget), OutputFormat="png"
         )
-        return response["MetricWidgetImage"].read()
+        return response["MetricWidgetImage"]
     except Exception:
         # A chart is a nice-to-have; never let it block the alarm itself.
         return None

--- a/sns-discord/test_lambda_function.py
+++ b/sns-discord/test_lambda_function.py
@@ -1,6 +1,5 @@
 import json
 import unittest
-from io import BytesIO
 from unittest.mock import patch
 
 from lambda_function import (
@@ -8,6 +7,7 @@ from lambda_function import (
     GREEN,
     RED,
     build_chart_widget,
+    build_payload,
     encode_multipart,
     fetch_chart_image,
     message_to_fields,
@@ -281,10 +281,43 @@ class FetchChartImageTest(unittest.TestCase):
     def test_success_returns_image_bytes(self):
         with patch("lambda_function.cloudwatch") as mock_cloudwatch:
             mock_cloudwatch.get_metric_widget_image.return_value = {
-                "MetricWidgetImage": BytesIO(b"\x89PNG...")
+                "MetricWidgetImage": b"\x89PNG..."
             }
             result = fetch_chart_image(FULL_TRIGGER)
         self.assertEqual(result, b"\x89PNG...")
+
+
+class BuildPayloadTest(unittest.TestCase):
+    def test_no_chart_keeps_fields_and_description(self):
+        post_data = {
+            "content": "hi",
+            "embed": {
+                "color": RED,
+                "description": "```json\n{}\n```",
+                "fields": [{"name": "a", "value": "b", "inline": True}],
+            },
+        }
+        payload = build_payload(post_data, None)
+        embed = payload["embeds"][0]
+        self.assertEqual(embed["description"], "```json\n{}\n```")
+        self.assertEqual(embed["fields"], [{"name": "a", "value": "b", "inline": True}])
+        self.assertNotIn("image", embed)
+
+    def test_chart_strips_fields_and_description(self):
+        post_data = {
+            "content": "hi",
+            "embed": {
+                "color": RED,
+                "description": "```json\n{}\n```",
+                "fields": [{"name": "a", "value": "b", "inline": True}],
+            },
+        }
+        payload = build_payload(post_data, b"\x89PNG...")
+        embed = payload["embeds"][0]
+        self.assertEqual(embed["description"], "")
+        self.assertEqual(embed["fields"], [])
+        self.assertEqual(embed["image"], {"url": "attachment://chart.png"})
+        self.assertEqual(embed["color"], RED)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Follow-up to #194. After deploying, invoking the live function showed the message text arriving in Discord but no chart image. Root cause: `GetMetricWidgetImage`'s `MetricWidgetImage` field is raw `bytes`, not a `StreamingBody` (unlike, say, S3's `GetObject`). The `.read()` call threw `AttributeError` on every real call, which `fetch_chart_image`'s broad `except Exception` silently swallowed, always falling back to the plain-JSON path. The unit test's mock used `BytesIO` (matching the *wrong* assumption), so it didn't catch this.

Verified locally against the live CloudWatch API and the real Discord webhook before pushing this: `MetricWidgetImage` is valid PNG bytes directly, and posting it now returns a real `attachment://chart.png` reference with a working CDN URL.

Also: once a chart is attached, the field-by-field JSON dump duplicates what's now visible in the graph, so `build_payload` (extracted from `lambda_handler` for testability) strips `description`/`fields` from the embed and keeps just `color` + `image` in that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)